### PR TITLE
simplify `feed.all`-resolver

### DIFF
--- a/components/screens/Home/Post/Post.tsx
+++ b/components/screens/Home/Post/Post.tsx
@@ -143,9 +143,9 @@ const Post = ({ data }: IPostProps) => {
           onClick={async () => {
             if (currentUser) {
               if (liked) {
-                unlikePost({ userId: currentUser?.id, postId: data.id });
+                unlikePost({ postId: data.id });
               } else {
-                likePost({ userId: currentUser?.id, postId: data.id });
+                likePost({ postId: data.id });
               }
               setLiked((l) => !l);
             }

--- a/components/screens/User/ActionButton.tsx
+++ b/components/screens/User/ActionButton.tsx
@@ -13,10 +13,7 @@ export const ActionButton = ({ id, username }: IActionButtonProps) => {
   const isPersonalProfile = session?.user?.id === id;
 
   const { data: following, refetch: refetchFollowing } = trpc.useQuery(
-    [
-      "following.active",
-      { userId: id, followerId: supabase.auth.user()?.id ?? "" },
-    ],
+    ["following.active", { userId: id }],
     { enabled: !isPersonalProfile }
   );
   const { mutateAsync: addFollowing, isLoading: isAddingFollowing } =
@@ -39,7 +36,6 @@ export const ActionButton = ({ id, username }: IActionButtonProps) => {
         await deleteFollowing({ id: following.id });
       } else {
         await addFollowing({
-          followerId: supabase.auth.user()?.id,
           userId: id,
         });
       }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,7 @@ import { withTRPC } from "@trpc/next";
 import { AppRouter } from "../server/routers/_app";
 import { httpLink } from "@trpc/client/links/httpLink";
 import superjson from "superjson";
+import { supabase } from "../lib/supabase";
 
 const queryClient = new QueryClient();
 
@@ -50,6 +51,9 @@ export default withTRPC<AppRouter>({
     return {
       links: [httpLink({ url })],
       transformer: superjson,
+      headers: {
+        Authorization: `Bearer ${supabase.auth.session()?.access_token}`,
+      },
       /**
        * @link https://react-query.tanstack.com/reference/QueryClient
        */

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,10 +14,7 @@ const Home = () => {
 
   const router = useRouter();
 
-  const { data: posts } = trpc.useQuery([
-    "feed.all",
-    { userId: supabase.auth.user()?.id },
-  ]);
+  const { data: posts } = trpc.useQuery(["feed.all"]);
 
   return (
     <>

--- a/server/context.ts
+++ b/server/context.ts
@@ -1,6 +1,8 @@
 import * as trpc from "@trpc/server";
 import * as trpcNext from "@trpc/server/adapters/next";
 import { prisma } from "../lib/prisma";
+import { supabase } from "../lib/supabase";
+
 /**
  * Creates context for an incoming request
  * @link https://trpc.io/docs/context
@@ -10,10 +12,23 @@ export const createContext = async ({
   res,
 }: trpcNext.CreateNextContextOptions) => {
   // for API-response caching see https://trpc.io/docs/caching
+
+  async function getUserFromHeader() {
+    if (req.headers.authorization) {
+      const { user } = await supabase.auth.api.getUser(
+        req.headers.authorization.split(" ")[1]
+      );
+      return user;
+    }
+    return null;
+  }
+  const user = await getUserFromHeader();
+
   return {
     req,
     res,
     prisma,
+    user,
   };
 };
 

--- a/server/middleware/authorization.ts
+++ b/server/middleware/authorization.ts
@@ -1,0 +1,19 @@
+import { User } from "@supabase/gotrue-js";
+import { TRPCError } from "@trpc/server";
+import { MiddlewareFunction } from "@trpc/server/dist/declarations/src/internals/middlewares";
+import { Context } from "../context";
+
+export const authorization: MiddlewareFunction<
+  Context,
+  Context & { user: User }
+> = ({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({ code: "UNAUTHORIZED" });
+  }
+  return next({
+    ctx: {
+      ...ctx,
+      user: ctx.user, // user value is known to be non-null now
+    },
+  });
+};

--- a/server/routers/_app.ts
+++ b/server/routers/_app.ts
@@ -1,6 +1,7 @@
 /**
  * This file contains the root router of your tRPC-backend
  */
+import { TRPCError } from "@trpc/server";
 import superjson from "superjson";
 import { createRouter } from "../createRouter";
 import { feedRouter } from "./feed";
@@ -22,11 +23,6 @@ export const appRouter = createRouter()
    * @link https://trpc.io/docs/data-transformers
    */
   .transformer(superjson)
-  /**
-   * Optionally do custom error (type safe!) formatting
-   * @link https://trpc.io/docs/error-formatting
-   */
-  // .formatError(({ shape, error }) => { })
   .merge("post.", postRouter)
   .merge("user.", userRouter)
   .merge("profileFeed.", profileFeedRouter)

--- a/server/routers/feed.ts
+++ b/server/routers/feed.ts
@@ -8,14 +8,8 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 
 export const feedRouter = createRouter().query("all", {
-  input: z.object({ userId: z.string().nullish() }),
+  input: z.object({ userId: z.string() }),
   async resolve({ ctx, input: { userId } }) {
-    if (!userId) {
-      throw new TRPCError({
-        code: "BAD_REQUEST",
-        message: `userId must not be null`,
-      });
-    }
     const followings = await (
       await ctx.prisma.user
         .findFirst({ where: { id: userId } })

--- a/server/routers/feed.ts
+++ b/server/routers/feed.ts
@@ -6,26 +6,28 @@
 import { createRouter } from "../../server/createRouter";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
+import { authorization } from "../middleware/authorization";
 
-export const feedRouter = createRouter().query("all", {
-  input: z.object({ userId: z.string() }),
-  async resolve({ ctx, input: { userId } }) {
-    const followings = await (
-      await ctx.prisma.user
-        .findFirst({ where: { id: userId } })
-        .followings({ include: { user: true } })
-    ).map((following) => following.user);
-    const posts = await ctx.prisma.post.findMany({
-      where: { author: { id: { in: followings.map((user) => user.id) } } },
-      include: { author: true, likes: true },
-      orderBy: [{ createdAt: "desc" }],
-    });
-    if (!posts) {
-      throw new TRPCError({
-        code: "NOT_FOUND",
-        message: `No posts with userId '${userId}'`,
+export const feedRouter = createRouter()
+  .middleware(authorization)
+  .query("all", {
+    async resolve({ ctx }) {
+      const followings = await (
+        await ctx.prisma.user
+          .findFirst({ where: { id: ctx.user.id } })
+          .followings({ include: { user: true } })
+      ).map((following) => following.user);
+      const posts = await ctx.prisma.post.findMany({
+        where: { author: { id: { in: followings.map((user) => user.id) } } },
+        include: { author: true, likes: true },
+        orderBy: [{ createdAt: "desc" }],
       });
-    }
-    return posts;
-  },
-});
+      if (!posts) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `No posts with userId '${ctx.user.id}'`,
+        });
+      }
+      return posts;
+    },
+  });

--- a/server/routers/like.ts
+++ b/server/routers/like.ts
@@ -6,34 +6,24 @@
 import { createRouter } from "../createRouter";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
+import { authorization } from "../middleware/authorization";
 
 export const likeRouter = createRouter()
+  .middleware(authorization)
   .mutation("create", {
-    input: z.object({ userId: z.string().nullish(), postId: z.number() }),
-    async resolve({ ctx, input: { userId, postId } }) {
-      if (!userId) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "userId is required",
-        });
-      }
+    input: z.object({ postId: z.number() }),
+    async resolve({ ctx, input: { postId } }) {
       const like = await ctx.prisma.postLike.create({
-        data: { userId, postId },
+        data: { userId: ctx.user.id, postId },
       });
       return like;
     },
   })
   .mutation("delete", {
-    input: z.object({ userId: z.string().nullish(), postId: z.number() }),
-    async resolve({ ctx, input: { userId, postId } }) {
-      if (!userId) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "userId is required",
-        });
-      }
+    input: z.object({ postId: z.number() }),
+    async resolve({ ctx, input: { postId } }) {
       await ctx.prisma.postLike.deleteMany({
-        where: { userId, postId },
+        where: { userId: ctx.user.id, postId },
       });
       return;
     },


### PR DESCRIPTION
Secondly, I think the supabase user should be propagated in the context so we don't even need to pass in a `userId`. Right now any user can get _any other_ user's feed.