### PR TITLE
fix: Use migration DB URL on prisma migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ DATABASE_URL="postgres://postgres:##############.supabase.co:6543/postgres?pgbou
 Now we can run Prisma to firstly perform our schema migration to Supabase and then generate our Prisma client locally:
 
 ```bash
-npx prisma migrate dev # Will setup the tables we need in Supabase from our schema
+yarn migrate:dev # Will setup the tables we need in Supabase from our schema
 ```
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "migrate:dev": "DATABASE_URL=$MIGRATE_DB_URL npx prisma migrate dev"
   },
   "dependencies": {
     "@prisma/client": "^2.26.0",


### PR DESCRIPTION
- Rather than running `npx prisma migrate dev` users should now use `yarn migrate:dev` which will hotswap the DATABASE_URL env for prisma to the MIGRATION_DATABASE_URL as prisma's migration engine does not work with pgBouncer as per this thread https://github.com/prisma/prisma/issues/6485#issuecomment-875162237